### PR TITLE
Get default signer at runtime

### DIFF
--- a/lib/joken/config.ex
+++ b/lib/joken/config.ex
@@ -145,16 +145,15 @@ defmodule Joken.Config do
 
       @behaviour Joken.Config
 
-      key = unquote(options)[:default_signer] || :default_signer
-
-      @joken_default_signer Joken.Signer.parse_config(key)
-
       @hooks [__MODULE__]
 
       @before_compile Joken.Config
 
       @doc false
-      def __default_signer__, do: @joken_default_signer
+      def __default_signer__ do
+        key = unquote(options)[:default_signer] || :default_signer
+        Joken.Signer.parse_config(key)
+      end
 
       @impl Joken.Config
       def token_config, do: default_claims()

--- a/lib/joken/config.ex
+++ b/lib/joken/config.ex
@@ -80,6 +80,7 @@ defmodule Joken.Config do
     - default_signer: a signer configuration key in config.exs (see `Joken.Signer`)
   """
   import Joken, only: [current_time: 0]
+  alias Joken.Signer
 
   @default_generated_claims [:exp, :iat, :nbf, :iss, :aud, :jti]
 
@@ -152,7 +153,7 @@ defmodule Joken.Config do
       @doc false
       def __default_signer__ do
         key = unquote(options)[:default_signer] || :default_signer
-        Joken.Signer.parse_config(key)
+        Signer.parse_config(key)
       end
 
       @impl Joken.Config


### PR DESCRIPTION
Setting `@joken_default_signer` as a module attribute requires that the config is set at compile time. This means that should a secret key be compromised, the user must recompile the whole application. Moving the `parse_config` method into the existing `__default_signer__` method will allow the user to swap out the config without recompiling the app.

Also, in our case and maybe others, besides wanting to be able to swap out the key without recompiling, it's a pain to ensure that environment variables are even available at compile time. Which is more our own problem, but still.

Fixes #211 