### PR TITLE
Plural time units are deprecated >= elixir1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,17 @@ language: elixir
 elixir:
   - 1.6.6
   - 1.7.3
+  - 1.8.0
 
 otp_release:
   - 19.3
   - 20.3
   - 21.1
+
+matrix:
+  exclude:
+    - otp_release: 19.3
+      elixir: 1.8.0
 
 script:
   - mix credo --strict

--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -189,7 +189,7 @@ defmodule Joken do
   @spec generate_jti() :: binary
   def generate_jti do
     binary = <<
-      System.system_time(:nanoseconds)::64,
+      System.system_time(:nanosecond)::64,
       :erlang.phash2({node(), self()}, 16_777_216)::24,
       :erlang.unique_integer()::32
     >>


### PR DESCRIPTION
I get this warning when compiling in elixir 1.8
warning: deprecated time unit: :nanoseconds. A time unit should be :second, :millisecond, :microsecond, :nanosecond, or a positive integer