### PR TITLE
Allow custom error messages on claim validation

### DIFF
--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -400,13 +400,8 @@ defmodule Joken do
             """
           end)
 
-          case config[key].options do
-            [message: custom_message] ->
-              {:halt, {:error, message: custom_message, claim: key, claim_val: claim_val}}
-
-            _ ->
-              {:halt, {:error, message: "Invalid token", claim: key, claim_val: claim_val}}
-          end
+          message = Keyword.get(config[key].options, :message, "Invalid token")
+          {:halt, {:error, message: message, claim: key, claim_val: claim_val}}
       end
     end)
     |> case do

--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -400,9 +400,12 @@ defmodule Joken do
             """
           end)
 
-          case config[key].options[:message] do
-            nil -> {:halt, {:error, message: "Invalid token", claim: key, claim_val: claim_val}}
-            custom_message -> {:halt, {:error, message: custom_message, claim: key, claim_val: claim_val}}
+          case config[key].options do
+            [message: custom_message] ->
+              {:halt, {:error, message: custom_message, claim: key, claim_val: claim_val}}
+
+            _ ->
+              {:halt, {:error, message: "Invalid token", claim: key, claim_val: claim_val}}
           end
       end
     end)

--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -34,7 +34,7 @@ defmodule Joken do
     - Signer configuration
     - Hooks
 
-  The portable token claims configuration is a map of binary keys to `Joken.Claim` structs and is used 
+  The portable token claims configuration is a map of binary keys to `Joken.Claim` structs and is used
   to dynamically generate and validate tokens.
 
   A signer is an instance of `Joken.Signer` that encapsulates the algorithm and the key configuration
@@ -400,7 +400,10 @@ defmodule Joken do
             """
           end)
 
-          {:halt, {:error, message: "Invalid token", claim: key, claim_val: claim_val}}
+          case config[key].options[:message] do
+            nil -> {:halt, {:error, message: "Invalid token", claim: key, claim_val: claim_val}}
+            custom_message -> {:halt, {:error, message: custom_message, claim: key, claim_val: claim_val}}
+          end
       end
     end)
     |> case do

--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -83,12 +83,17 @@ defmodule JokenTest do
 
       token_config =
         %{}
-        |> add_claim("iss", fn -> "not someone" end, fn val ->
-          val == "not someone"
-        end, %{message: custom_error_message})
+        |> add_claim(
+          "iss",
+          fn -> "not someone" end,
+          fn val ->
+            val == "not someone"
+          end,
+          message: custom_error_message
+        )
 
       assert {:error, [message: custom_error_message, claim: "iss", claim_val: "someone"]} ==
-                Joken.validate(token_config, %{"iss" => "someone"}, %{})
+               Joken.validate(token_config, %{"iss" => "someone"}, %{})
     end
 
     test "can make multi claim validation" do

--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -1,7 +1,7 @@
 defmodule JokenTest do
   use ExUnit.Case, async: true
   import ExUnit.CaptureLog
-  import Joken.Config, only: [add_claim: 4, default_claims: 1]
+  import Joken.Config, only: [add_claim: 4, add_claim: 5, default_claims: 1]
   alias Joken.CurrentTime.Mock
 
   setup do
@@ -76,6 +76,19 @@ defmodule JokenTest do
 
       assert capture_log(validate_fun) =~
                "Claim %{\"iss\" => \"someone\"} did not pass validation.\n\nCurrent time: "
+    end
+
+    test "claim attaches custom error message" do
+      custom_error_message = "Someone should not be there"
+
+      token_config =
+        %{}
+        |> add_claim("iss", fn -> "not someone" end, fn val ->
+          val == "not someone"
+        end, %{message: custom_error_message})
+
+      assert {:error, [message: custom_error_message, claim: "iss", claim_val: "someone"]} ==
+                Joken.validate(token_config, %{"iss" => "someone"}, %{})
     end
 
     test "can make multi claim validation" do


### PR DESCRIPTION
Previous to 2.x, using `with_validation` would allow you to set a custom error message. The ability, as far as I can tell, was lost in 2.x. The PR would bring back some of the functionality. I'm open to any suggested changes!