### PR TITLE
Fix small typo in "Asymmetric cryptography signers" guide

### DIFF
--- a/guides/assymetric_cryptography_signers.md
+++ b/guides/assymetric_cryptography_signers.md
@@ -93,7 +93,7 @@ use Mix.Config
 
 config :joken, 
   my_rsa_key: [
-    signer_alg: "RS256".
+    signer_alg: "RS256",
     key_pem: """
     -----BEGIN RSA PRIVATE KEY-----
     MIICWwIBAAKBg


### PR DESCRIPTION
Fix small typo in "Asymmetric cryptography signers" guide (. -> ,)