### PR TITLE
fix: treat improper token properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Changed
 ### Fixed
 
+- (@polvalente) Fix issue where Base.decode64 :error return could bleed trough as {:ok, :error} when using pre_verification hooks
+
 ## [2.1.0] - 2019-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Changed
 ### Fixed
 
-- (@polvalente) Fix issue where Base.decode64 :error return could bleed trough as {:ok, :error} (#237)
+- (@polvalente) Fix issue where Base.decode64 made peek_claims and peek_header return out of spec (#237)
 
 ## [2.1.0] - 2019-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Changed
 ### Fixed
 
-- (@polvalente) Fix issue where Base.decode64 :error return could bleed trough as {:ok, :error} when using pre_verification hooks
+- (@polvalente) Fix issue where Base.decode64 :error return could bleed trough as {:ok, :error} (#237)
 
 ## [2.1.0] - 2019-05-27
 

--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -134,7 +134,7 @@ defmodule Joken do
          header <- JOSE.json_module().decode(decoded_str) do
       {:ok, header}
     else
-      {:decode64, _error} -> {:error, :malformed_token}
+      {:decode64, _error} -> {:error, :token_malformed}
       error -> error
     end
   end
@@ -155,7 +155,7 @@ defmodule Joken do
          claims <- JOSE.json_module().decode(decoded_str) do
       {:ok, claims}
     else
-      {:decode64, _error} -> {:error, :malformed_token}
+      {:decode64, _error} -> {:error, :token_malformed}
       error -> error
     end
   end

--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -134,7 +134,7 @@ defmodule Joken do
          header <- JOSE.json_module().decode(decoded_str) do
       {:ok, header}
     else
-      {:decode64, _error} -> {:error, :improper_token}
+      {:decode64, _error} -> {:error, :malformed_token}
       error -> error
     end
   end
@@ -155,7 +155,7 @@ defmodule Joken do
          claims <- JOSE.json_module().decode(decoded_str) do
       {:ok, claims}
     else
-      {:decode64, _error} -> {:error, :improper_token}
+      {:decode64, _error} -> {:error, :malformed_token}
       error -> error
     end
   end

--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -129,10 +129,12 @@ defmodule Joken do
   @spec peek_header(bearer_token) :: {:ok, claims} | {:error, error_reason}
   def peek_header(token) when is_binary(token) do
     with {:ok, %{"protected" => protected}} <- expand(token),
-         {:ok, decoded_str} <- Base.url_decode64(protected, padding: false),
+         {:decode64, {:ok, decoded_str}} <-
+           {:decode64, Base.url_decode64(protected, padding: false)},
          header <- JOSE.json_module().decode(decoded_str) do
       {:ok, header}
     else
+      {:decode64, _error} -> {:error, :improper_token}
       error -> error
     end
   end

--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -150,10 +150,12 @@ defmodule Joken do
   @spec peek_claims(bearer_token) :: {:ok, claims} | {:error, error_reason}
   def peek_claims(token) when is_binary(token) do
     with {:ok, %{"payload" => payload}} <- expand(token),
-         {:ok, decoded_str} <- Base.url_decode64(payload, padding: false),
+         {:decode64, {:ok, decoded_str}} <-
+           {:decode64, Base.url_decode64(payload, padding: false)},
          claims <- JOSE.json_module().decode(decoded_str) do
       {:ok, claims}
     else
+      {:decode64, _error} -> {:error, :improper_token}
       error -> error
     end
   end

--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -164,7 +164,7 @@ defmodule JokenTest do
 
   test "peek_header and peek_claims give proper error upon improper token, instead of returning out of spec :error" do
     # This test ensures that peek_header and peek_claims use Base.url_decode64 properly
-    assert {:error, :improper_token} = Joken.peek_claims(".a.")
-    assert {:error, :improper_token} = Joken.peek_header("a..")
+    assert {:error, :malformed_token} = Joken.peek_claims(".a.")
+    assert {:error, :malformed_token} = Joken.peek_header("a..")
   end
 end

--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -162,38 +162,9 @@ defmodule JokenTest do
     assert Joken.peek_claims(token) == {:ok, %{"some" => custom_claim}}
   end
 
-  test "verify_and_validate, peek_header and peek_claims give proper error upon improper token, instead of raising" do
+  test "peek_header and peek_claims give proper error upon improper token, instead of returning out of spec :error" do
     # This test ensures that peek_header and peek_claims use Base.url_decode64 properly
-
-    defmodule HeaderHook do
-      use Joken.Hooks
-
-      @impl true
-      def before_verify(_options, {token, signer}) do
-        with {:ok, _} <- Joken.peek_header(token) do
-          {:cont, {token, signer}}
-        else
-          error -> {:halt, error}
-        end
-      end
-    end
-
-    defmodule ClaimsHook do
-      use Joken.Hooks
-
-      @impl true
-      def before_verify(_options, {token, signer}) do
-        with {:ok, _} <- Joken.peek_claims(token) do
-          {:cont, {token, signer}}
-        else
-          error -> {:halt, error}
-        end
-      end
-    end
-
-    signer = Joken.Signer.create("HS256", "secret")
-
-    assert {:error, :improper_token} = Joken.verify("a.a.a", signer, [{HeaderHook, []}])
-    assert {:error, :improper_token} = Joken.verify("a.a.a", signer, [{ClaimsHook, []}])
+    assert {:error, :improper_token} = Joken.peek_claims(".a.")
+    assert {:error, :improper_token} = Joken.peek_header("a..")
   end
 end

--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -183,7 +183,7 @@ defmodule JokenTest do
 
       @impl true
       def before_verify(_options, {token, signer}) do
-        with {:ok, _} <- Joken.peek_header(token) do
+        with {:ok, _} <- Joken.peek_claims(token) do
           {:cont, {token, signer}}
         else
           error -> {:halt, error}

--- a/test/joken_test.exs
+++ b/test/joken_test.exs
@@ -164,7 +164,7 @@ defmodule JokenTest do
 
   test "peek_header and peek_claims give proper error upon improper token, instead of returning out of spec :error" do
     # This test ensures that peek_header and peek_claims use Base.url_decode64 properly
-    assert {:error, :malformed_token} = Joken.peek_claims(".a.")
-    assert {:error, :malformed_token} = Joken.peek_header("a..")
+    assert {:error, :token_malformed} = Joken.peek_claims(".a.")
+    assert {:error, :token_malformed} = Joken.peek_header("a..")
   end
 end


### PR DESCRIPTION
# Context

This pull request originated from a Joken crash when sending invalid tokens that contained two ".", like `a.a.a` or `..`. These tokens match correctly on `[_, _, _] = String.split(token, ".")`, thus passing a first validation layer (`Joken.expand(token)`).

Furthermore, when using `before_verify` or `before_validate` hooks that used `Joken.peek_claims` or `Joken.peek_header`, there could be a problem where said invalid tokens would bleed through as `{:ok, :error}`, thus causing the crash (as it was expected to return `{:ok, %{} = claims}` instead of `{:ok, atom}`)

# Fix

Instead of relying on just passing through the `Base.decode64` error return, it needs to be wrapped as a `{:error, improper_token}` tuple.

The test added ensures that both scenarios are now returning an error as expected