### PR TITLE
Access current_time_adapter in runtime instead of compile time

### DIFF
--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -101,9 +101,6 @@ defmodule Joken do
   @type verify_result :: {:ok, claims} | {:error, error_reason}
   @type validate_result :: {:ok, claims} | {:error, error_reason}
 
-  # This ensures we provide an easy to setup test environment
-  @current_time_adapter Application.get_env(:joken, :current_time_adapter, Joken.CurrentTime.OS)
-
   @doc """
   Retrieves current time in seconds.
 
@@ -116,7 +113,7 @@ defmodule Joken do
   See Joken's own tests for an example of how to override this with a customizable time mock.
   """
   @spec current_time() :: pos_integer
-  def current_time, do: @current_time_adapter.current_time()
+  def current_time, do: current_time_adapter().current_time()
 
   @doc """
   Decodes the header of a token without validation.
@@ -413,4 +410,8 @@ defmodule Joken do
       err -> err
     end
   end
+
+  # This ensures we provide an easy to setup test environment
+  defp current_time_adapter,
+    do: Application.get_env(:joken, :current_time_adapter, Joken.CurrentTime.OS)
 end


### PR DESCRIPTION
This fixes issue #236 

I tried using Mox to inject a `Joken.CurrentTime.Mock` instance but it did not work because the way Joken was accessing the adapter using module attributes which are resolved at compile time instead of runtime. 

By using a private function to access the adapter, we make sure that the adapter is resolved at runtime.