### PR TITLE
Bump version 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,15 @@ elixir:
 otp_release:
   - 21.2
   - 22.3
-  - 23.1
+  - 23.0
 
 matrix:
   exclude:
-    - otp_release: 23.1
+    - otp_release: 23.0
       elixir: 1.7.4
-    - otp_release: s23.1
+    - otp_release: 23.0
       elixir: 1.8.1
-    - otp_release: 23.1
+    - otp_release: 23.0
       elixir: 1.9.4      
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## [Unreleased]
 
+## [2.3.0] - 2020-09-27
+
+### Changed
+
+- (@supersimple with @bryanjos) Update CHANGELOG.md (#257)
+- (@victorolinasc) chore: add public PEM only signer test
+- (@victorolinasc) chore: update deps
+- (@victorolinasc) Adding error handling (#277)
+- (@ideaMarcos) Update common_use_cases.md (#285)
+- (@victorolinasc) Clean up versions and compatibility with OTP 23 (#291)
+
+### Fixed
+
+- (@woylie) fix type specs and doc (#266)
+
 ## [2.2.0] - 2019-11-08
 
 ### Added

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Joken.Mixfile do
   use Mix.Project
 
-  @version "2.2.0"
+  @version "2.3.0"
 
   def project do
     [


### PR DESCRIPTION
## [2.3.0] - 2020-09-27

### Changed

- (@supersimple with @bryanjos) Update CHANGELOG.md (#257)
- (@victorolinasc) chore: add public PEM only signer test
- (@victorolinasc) chore: update deps
- (@victorolinasc) Adding error handling (#277)
- (@ideaMarcos) Update common_use_cases.md (#285)
- (@victorolinasc) Clean up versions and compatibility with OTP 23 (#291)