### PR TITLE
Fix missing argument in docs for signers

### DIFF
--- a/guides/signers.md
+++ b/guides/signers.md
@@ -87,7 +87,7 @@ MIICWwIBAAKBgQDdlatRjRjogo3WojgGHFHYLugdUWAY9iR3fy4arWNA1KoS8kVw33cJibXr8bvwUAUp
 If you are creating a signer explicitly, you need to pass the PEM in a map with the key PEM. Example:
 
 ``` elixir
-signer = Joken.Signer.create(%{"pem" => key_pem})
+signer = Joken.Signer.create("RS512", %{"pem" => key_pem})
 ```
 
 Inside a PEM you can put several things. It may hold more than just a private key. For Joken, though, it might get a bit funky if you pass a PEM with several things in it. After all, we are trying to read a key from it and we are not actually a library for being compliant with PEM standard.


### PR DESCRIPTION
Hello 👋 

I just read the docs on signers and realised, that they have a little error. 
`Joken.Signer.create/1` does not exist. 

One has to pass in the algorithm name as a first argument to make it work. 
I am not sure if it is possible to auto-detect the algorithm somehow (I guess not 🤷 ).

Since the example above references `RS512` I thought I go with the same one.

Cheers 
Andi