### PR TITLE
Joken.Config.validate has an arity of 2, but is marked overrideable with arity 1

### DIFF
--- a/lib/joken/config.ex
+++ b/lib/joken/config.ex
@@ -36,7 +36,7 @@ defmodule Joken.Config do
     - `generate_claims/1`: generates dynamic claims and adds them to the passed map.
     - `encode_and_sign/2`: takes a map of claims, encodes it to JSON and signs it.
     - `verify/2`: check for token tampering using a signer.
-    - `validate/1`: takes a claim map and a configuration to run validations.
+    - `validate/2`: takes a claim map and a configuration to run validations.
     - `generate_and_sign/2`: combines generation and signing.
     - `verify_and_validate/2`: combines verification and validation.
     - `token_config/0`: where you customize token generation and validation.
@@ -137,7 +137,7 @@ defmodule Joken.Config do
   @doc """
   Runs validations on the already verified token.
   """
-  @callback validate(Joken.claims()) :: {:ok, Joken.claims()} | {:error, Joken.error_reason()}
+  @callback validate(Joken.claims(), term) :: {:ok, Joken.claims()} | {:error, Joken.error_reason()}
 
   defmacro __using__(options) do
     quote do
@@ -190,7 +190,7 @@ defmodule Joken.Config do
                      generate_claims: 1,
                      encode_and_sign: 2,
                      verify: 2,
-                     validate: 1
+                     validate: 2
 
       @doc "Combines `generate_claims/1` and `encode_and_sign/2`"
       @spec generate_and_sign(Joken.claims(), Joken.signer_arg()) ::
@@ -204,7 +204,7 @@ defmodule Joken.Config do
       def generate_and_sign!(extra_claims \\ %{}, key \\ __default_signer__()),
         do: Joken.generate_and_sign!(token_config(), extra_claims, key, __hooks__())
 
-      @doc "Combines `verify/2` and `validate/1`"
+      @doc "Combines `verify/2` and `validate/2`"
       @spec verify_and_validate(Joken.bearer_token(), Joken.signer_arg(), term) ::
               {:ok, Joken.claims()} | {:error, Joken.error_reason()}
       def verify_and_validate(bearer_token, key \\ __default_signer__(), context \\ %{}),

--- a/lib/joken/error.ex
+++ b/lib/joken/error.ex
@@ -89,7 +89,7 @@ defmodule Joken.Error do
     When it is 2, besides the claim value, it receives a context map. You can pass dynamic
     values on this context and pass it to the validate function.
 
-    See `Joken.Config.validate/3` for more information on Context
+    See `Joken.Config.validate/2` for more information on Context
     """
 
   def message(%__MODULE__{reason: :wrong_key_parameters}),


### PR DESCRIPTION
It currently isn't possible to override the Joken.Config.validate callback, I think because `defoverridable` has the wrong arity for `validate`. This PR attempts to fix that.

I haven't added or updated any tests -- please let me know if there's an appropriate place to add one.

Currently, if you attempt to specify two arguments like so:

    @impl true
    def validate(claims, context) do
       ... etc ...
    end

You get a compiler warning that a previous clause always matches.

If you specify with only one argument:

    @impl true
    def validate(claims) do
       ... etc ...
    end

You get a compiler error that `validate/1` conflicts with defaults from `validate/2`.