### PR TITLE
Update version and changelog

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,12 +33,20 @@ jobs:
       fail-fast: false
       matrix:
         elixir:
-        - "1.8.1"
-        - "1.10.4"
-        - "1.12.2"
+          - "1.8.2"
+          - "1.10.4"
+          - "1.12.2"
         otp:
-        - "23.3"
-        - "24.0"
+          - "22.3"
+          - "23.3"
+          - "24.0"
+        exclude:
+          - elixir: "1.8.2"
+            otp: "23.3"
+          - elixir: "1.8.2"
+            otp: "24.0"
+          - elixir: "1.12.2"
+            otp: "22.3"
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,20 +37,8 @@ jobs:
         - "1.10.4"
         - "1.12.2"
         otp:
-        - "21.2"
         - "23.3"
         - "24.0"
-        exclude:
-        - elixir: "1.8.1"
-          otp: "23.3"
-        - elixir: "1.8.1"
-          otp: "24.0"
-        - elixir: "1.9.4"
-          otp: "23.3"
-        include:
-          - elixir: "1.11.4"
-            otp: "23.3"
-            lint: lint
 
     runs-on: ubuntu-latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## [Unreleased]
 
+## [2.4.0] - 2021-08-15
+
+### Changed
+
+- Major docs reviews and corrections (thanks to @kianmeng, @andreasknoepfle, Jon Forsyth, @fuelen)
+- Change of CI pipeline (thanks to @dolfinus)
+- Now uses Elixir 1.8 as minimum (and actually test the mininum version on CI)
+
+### Fixed
+
+- Fixed arity of `Joken.Config.validate` (thanks to @blagh)
+- Compatibility with OTP 24.0 with JOSE update to 1.11.2
+
 ## [2.3.0] - 2020-09-27
 
 ### Changed

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Joken.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/joken-elixir/joken"
-  @version "2.3.0"
+  @version "2.4.0"
 
   def project do
     [


### PR DESCRIPTION
- Joken now demands Elixir 1.8+
- Updated JOSE to 1.11.2 (brings OTP 24 support)
- Major fixes and reviews in the documentation