### PR TITLE
Fix generate_and_sign examples in guides' documentation

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -97,7 +97,7 @@ defmodule MyApp.Token do
   end
 end
 
-{:ok, token} = MyApp.Token.generate_and_sign()
+{:ok, token, claims} = MyApp.Token.generate_and_sign()
 
 {:ok, claims} = MyApp.Token.verify_and_validate(token)
 

--- a/guides/introduction.md
+++ b/guides/introduction.md
@@ -58,7 +58,7 @@ end
 Then, just use your module :)
 
 ``` elixir
-{:ok, token_with_default_claims} = MyApp.Token.generate_and_sign()
+{:ok, token, claims} = MyApp.Token.generate_and_sign()
 
 extra_claims = %{"user_id" => "some_id"}
 token_with_default_plus_custom_claims = MyApp.Token.generate_and_sign!(extra_claims)
@@ -74,7 +74,7 @@ Or with explicit signer:
 ``` elixir
 signer = Joken.Signer.create("HS256", "secret")
 
-{:ok, token_with_default_claims} = MyApp.Token.generate_and_sign(%{}, signer)
+{:ok, token, claims} = MyApp.Token.generate_and_sign(%{}, signer)
 
 extra_claims = %{"user_id" => "some_id"}
 token_with_default_plus_custom_claims = MyApp.Token.generate_and_sign!(extra_claims, signer)

--- a/guides/signers.md
+++ b/guides/signers.md
@@ -119,7 +119,7 @@ defmodule MyCustomAuth do
   use Joken.Config
 end
 
-# Usign default signer configuration
+# Using default signer configuration
 MyCustomAuth.generate_and_sign()
 
 # Explicit Signer instance


### PR DESCRIPTION
The function `generate_and_sign()` returns `{:ok, token, claims}`. The examples given in the guides' documentation return only `{:ok, token_with_claims}`, witch generates a match error. This PR fixes it.

Also, I fixed a little typo in the Signers documentation.