### PR TITLE
Remove no_return from methods that can return

### DIFF
--- a/lib/joken.ex
+++ b/lib/joken.ex
@@ -220,7 +220,7 @@ defmodule Joken do
 
   @doc "Same as `generate_and_sign/4` but raises if result is an error"
   @spec generate_and_sign!(token_config, claims, signer_arg, [module]) ::
-          bearer_token | no_return()
+          bearer_token
   def generate_and_sign!(
         token_config,
         extra_claims \\ %{},
@@ -306,7 +306,7 @@ defmodule Joken do
 
   @doc "Same as `verify_and_validate/5` but raises on error"
   @spec verify_and_validate!(token_config, bearer_token, signer_arg, term, hooks) ::
-          claims | no_return()
+          claims
   def verify_and_validate!(
         token_config,
         bearer_token,

--- a/lib/joken/config.ex
+++ b/lib/joken/config.ex
@@ -201,7 +201,7 @@ defmodule Joken.Config do
 
       @doc "Same as `generate_and_sign/2` but raises if error"
       @spec generate_and_sign!(Joken.claims(), Joken.signer_arg()) ::
-              Joken.bearer_token() | no_return()
+              Joken.bearer_token()
       def generate_and_sign!(extra_claims \\ %{}, key \\ __default_signer__()),
         do: Joken.generate_and_sign!(token_config(), extra_claims, key, __hooks__())
 
@@ -213,7 +213,7 @@ defmodule Joken.Config do
 
       @doc "Same as `verify_and_validate/2` but raises if error"
       @spec verify_and_validate!(Joken.bearer_token(), Joken.signer_arg(), term) ::
-              Joken.claims() | no_return()
+              Joken.claims()
       def verify_and_validate!(bearer_token, key \\ __default_signer__(), context \\ %{}),
         do: Joken.verify_and_validate!(token_config(), bearer_token, key, context, __hooks__())
     end


### PR DESCRIPTION
Using any of the bang methods was causing dialyxir to complain about not handling `no_return` case. Looking into it I dug this up which seems like `no_return` _should_ not be used for functions that don't always fail.

## Reference

Taken from danschultzer/pow#543:

> [...] in this PR elixir-lang/elixir#8092 shows that mixed no_return/0 with return in specs was removed from Elixir.
> 
> As Jose writes in elixir-lang/elixir#8631 (comment):
> 
> > `no_return` is not correct though because that function can return in some situations. We only use no_return when the function is always fail. So this error is happening because dialyzer thinks something somewhere inside those functions will always fail.