### PR TITLE
Migrate to Config from Mix.Config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 case Mix.env() do
   # Use the same key config as tests for benchmarking

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Config
 
 config :joken, default_signer: "s3cr3t"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+# and its dependencies with the aid of the Config module.
+import Config
 
 rsa_map_key = %{
   "d" =>


### PR DESCRIPTION
Since this library have moved to Elixir 1.10, this resolves the warning
of `use Mix.Config is deprecated. Use the Config module instead`.