### PR TITLE
handle non binary hmac sha key error

### DIFF
--- a/lib/joken/error.ex
+++ b/lib/joken/error.ex
@@ -92,6 +92,13 @@ defmodule Joken.Error do
     See `Joken.Config.validate/2` for more information on Context
     """
 
+  def message(%__MODULE__{reason: :algorithm_needs_binary_key}),
+    do: """
+    Couldn't create a signer because key is not binary.
+
+    HMAC SHA algorithms need a binary key.
+    """
+
   def message(%__MODULE__{reason: :wrong_key_parameters}),
     do: """
     Couldn't create a signer because there are missing parameters.

--- a/lib/joken/signer.ex
+++ b/lib/joken/signer.ex
@@ -80,6 +80,9 @@ defmodule Joken.Signer do
     )
   end
 
+  def create(alg, _key, _headers) when alg in @hs_algorithms,
+    do: raise(Joken.Error, :algorithm_needs_binary_key)
+
   def create(alg, %{"pem" => pem}, headers) when alg in @map_key_algorithms do
     raw_create(
       alg,

--- a/lib/joken/signer.ex
+++ b/lib/joken/signer.ex
@@ -99,7 +99,8 @@ defmodule Joken.Signer do
   def create(alg, _key, _headers) when alg in @map_key_algorithms,
     do: raise(Joken.Error, :algorithm_needs_key)
 
-  def create(_, _, _), do: raise(Joken.Error, :unrecognized_algorithm)
+  def create(alg, _, _) when alg not in @algorithms,
+    do: raise(Joken.Error, :unrecognized_algorithm)
 
   defp raw_create(alg, jws, jwk) do
     %__MODULE__{

--- a/lib/joken/signer.ex
+++ b/lib/joken/signer.ex
@@ -99,8 +99,7 @@ defmodule Joken.Signer do
   def create(alg, _key, _headers) when alg in @map_key_algorithms,
     do: raise(Joken.Error, :algorithm_needs_key)
 
-  def create(alg, _, _) when alg not in @algorithms,
-    do: raise(Joken.Error, :unrecognized_algorithm)
+  def create(_, _, _), do: raise(Joken.Error, :unrecognized_algorithm)
 
   defp raw_create(alg, jws, jwk) do
     %__MODULE__{

--- a/test/joken_signer_test.exs
+++ b/test/joken_signer_test.exs
@@ -81,6 +81,12 @@ defmodule Joken.Signer.Test do
     end
   end
 
+  test "raise when key is invalid" do
+    assert_raise Error, Error.message(%Error{reason: :algorithm_needs_binary_key}), fn ->
+      Signer.create("HS256", %{})
+    end
+  end
+
   test "raise when parsing invalid algorithm from configuration" do
     assert_raise Error, Error.message(%Error{reason: :unrecognized_algorithm}), fn ->
       Signer.parse_config(:bad_algorithm)


### PR DESCRIPTION
Hi! Did not know whether I should have opened an issue first, so feel free to close this if not applicable.

I've recently observed the following situation:

```
iex> Joken.Signer.create("HS256", nil, nil)

** (Joken.Error) Couldn't recognize the signer algorithm.

Possible values are:

["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512", "Ed25519", "Ed25519ph", "Ed448", "Ed448ph"]
```

which is confusing since the `"HS256"` is the first one in the list of possible values. The cause seems to be that when the algorithm is one of the HSXXX and the secret is not binary the only clause that matches is the unrecognized algorithm one.

The changes in this PR ensures that an unrecognized algorithm error only happens if the algorithm is indeed unrecognized. The offending code now raises a FunctionClauseError.

I thought about adding a test for this but since I saw no test for other malformed inputs (such as `create("HS256", "", nil)` raising a BadMapError), I decided to leave it as it is. 

Thanks for the library!
