### PR TITLE
fix(typespec): fix after_sign spec

### DIFF
--- a/lib/joken/hooks.ex
+++ b/lib/joken/hooks.ex
@@ -131,7 +131,7 @@ defmodule Joken.Hooks do
   @doc "Called after `Joken.encode_and_sign/3`"
   @callback after_sign(
               hook_options,
-              Joken.sign_result(),
+              {:ok, Joken.bearer_token()} | {:error, Joken.error_reason()},
               sign_input
             ) :: {:cont, Joken.sign_result(), sign_input} | halt_tuple
 


### PR DESCRIPTION
The `after_sign` callback receives the result of `Joken.Signer.sign` and not `Joken.encode_and_sign`. Therefore the spec was wrong!

Fixes #368 