### PR TITLE
Fix incorrect function signature in docs

### DIFF
--- a/guides/asymmetric_cryptography_signers.md
+++ b/guides/asymmetric_cryptography_signers.md
@@ -83,7 +83,7 @@ To use it with Joken we can call one of the `Joken.Signer.create` variants:
 1.  With the RAW PEM contents:
 
     ``` elixir
-    signer = Joken.Signer.create(%{"pem" => pem_contents})
+    signer = Joken.Signer.create("RS256", %{"pem" => pem_contents})
     ```
 
 2.  With the pem file in the configuration:


### PR DESCRIPTION
The "Asymmetric cryptography signers" guide referenced a `Joken.Signer.create/1` function, which does not exist. This change adds the initial argument such that it is a valid call.