### PR TITLE
Joken.Signer hides private data when inspected

### DIFF
--- a/lib/joken/signer.ex
+++ b/lib/joken/signer.ex
@@ -32,6 +32,7 @@ defmodule Joken.Signer do
           alg: binary() | nil
         }
 
+  @derive {Inspect, except: [:jwk]}
   defstruct jwk: nil, jws: nil, alg: nil
 
   @doc """

--- a/test/joken_signer_test.exs
+++ b/test/joken_signer_test.exs
@@ -73,7 +73,7 @@ defmodule Joken.Signer.Test do
   test "it does not display private data when printed" do
     signer = Joken.Signer.create("HS256", "s3cret")
     stdout = capture_io(fn -> IO.inspect(signer) end)
-    assert String.contains?(stdout, "#Joken.Signer<")
+    assert match?("#Joken.Signer<" <> _, stdout)
     refute String.contains?(stdout, "jwk")
   end
 

--- a/test/joken_signer_test.exs
+++ b/test/joken_signer_test.exs
@@ -3,6 +3,7 @@ defmodule Joken.Signer.Test do
   alias Joken.{Error, Signer}
 
   doctest Signer
+  import ExUnit.CaptureIO
 
   # Tests below "may" break in future OTP versions. This is related to the
   # supported algorithms in the crypto module. Current expected behaviour is
@@ -67,6 +68,13 @@ defmodule Joken.Signer.Test do
              },
              jwk: %JOSE.JWK{}
            } = signer
+  end
+
+  test "it does not display private data when printed" do
+    signer = Joken.Signer.create("HS256", "s3cret")
+    stdout = capture_io(fn -> IO.inspect(signer) end)
+    assert String.contains?(stdout, "#Joken.Signer<")
+    refute String.contains?(stdout, "jwk")
   end
 
   test "raise with invalid parameter" do


### PR DESCRIPTION
Related to https://github.com/joken-elixir/joken/issues/383