### PR TITLE
Add test for ES256

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -92,6 +92,14 @@ CSAnW8Md2j56RkvCnSPGab8eh5BjoGEInmSZWpUXvLJt91pZqX1jSbs1ZNg=
 -----END RSA PRIVATE KEY-----
 """
 
+ec_pem_key = """
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIBEdk34npuxz13CvGk/BS39dZ+2XAR6k9S4uNhtEMd3AoAoGCCqGSM49
+AwEHoUQDQgAExCkF/6mwf3HoEv4m+1+Pi702herRxJeycLHXiRpA8Nkj8tVjU9C6
+5CRx1TdE4q4I8ympW4HrBm2qpPi3z6mEGw==
+-----END EC PRIVATE KEY-----
+"""
+
 # generated with openssl genrsa -aes256 4096
 rsa_encrypted_passphrase = "passphrase"
 
@@ -182,6 +190,10 @@ config :joken,
   pem_rs256: [
     signer_alg: "RS256",
     key_pem: rsa_pem_key
+  ],
+  pem_es256: [
+    signer_alg: "ES256",
+    key_pem: ec_pem_key
   ],
   pem_encrypted_rs256: [
     signer_alg: "RS256",

--- a/test/joken_signer_test.exs
+++ b/test/joken_signer_test.exs
@@ -56,6 +56,19 @@ defmodule Joken.Signer.Test do
            } = signer
   end
 
+  test "can create a signer from an EC private key" do
+    pem = Application.get_env(:joken, :pem_es256)[:key_pem]
+    signer = Signer.create("ES256", %{"pem" => pem})
+
+    assert %Signer{
+             alg: "ES256",
+             jws: %JOSE.JWS{
+               alg: {:jose_jws_alg_ecdsa, :ES256}
+             },
+             jwk: %JOSE.JWK{}
+           } = signer
+  end
+
   test "can create a signer from an encrypted key" do
     pem = Application.get_env(:joken, :pem_encrypted_rs256)[:key_pem]
     passphrase = Application.get_env(:joken, :pem_encrypted_rs256)[:passphrase]


### PR DESCRIPTION
:wave: from a new user.

I was attempting to use joken to sign EC private keys and I can't seem to get it to work. I didn't see a test for ES256 so I figured I'd add it. I've included a burned private key in the tests (I have deleted it from the source).

Anyway, I'm back to debugging but thanks for this library. I assume my problem is PEBKAC but if you know of any reason why the following appears to always return 401 in the request for me, I'm all 👂  :bow:

```elixir
Joken.Signer.create(
  "ES256",
  %{"pem" => "--------BEGIN EC PRIVATE KEY-----\nM..."
)
```
cc @victorolinasc